### PR TITLE
Make prefix optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ jobs:
         with:
           repo: keybase://team/your_team/your_repo
           file: secrets/secret.json
+          prefix: "keybase-secret-" # optional (passing empty string will preserve filename)
         env:
           KEYBASE_PAPERKEY: ${{ secrets.KEYBASE_PAPERKEY }}
           KEYBASE_USERNAME: ${{ secrets.KEYBASE_USERNAME }}

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
   file:
     description: 'The file to get'
     required: true
+  prefix:
+    description: 'A prefix to name the file with'
+    required: false
+    default: "keybase-secret-"
 
 outputs:
   file:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,10 @@
-#!/bin/bash -ue
+#!/usr/bin/env bash
+set -e
 
-repo=$1
-file=$2
-output=keybase-secret-${file/\//-}
+repo="${1}"
+file="${2}"
+prefix="${3:keybase-secret-}"
+output="${prefix}${file/\//-}"
 
 export KEYBASE_ALLOW_ROOT=1
 
@@ -12,6 +14,6 @@ keybase oneshot
 
 git clone $repo $HOME/secrets
 
-cp $HOME/secrets/$file $output
+cp "${HOME}/secrets/${file}" "${output}"
 
 echo ::set-output name=file::$output


### PR DESCRIPTION
Currently, the prefix is required and forces you to place your copied file into a folder. This change allows that prefix to be optional, and if it is not passed in creating the file at the root.