### PR TITLE
Update Keybase action to remove dependency on naps docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM keybaseio/client:stable-alpine
+FROM keybaseio/client:6.1.1-20230104121127-93463966d2-alpine
 
 RUN apk add git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM naps62/keybase:2019-11-26
+FROM keybaseio/client:stable-alpine
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM keybaseio/client:stable-alpine
 
+RUN apk add git
+
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,9 @@ repo=$1
 file=$2
 output=keybase-secret-${file/\//-}
 
-export KEYBASE_SERVICE=1
+export KEYBASE_ALLOW_ROOT=1
+
+keybase oneshot
 
 git clone $repo $HOME/secrets
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,14 +4,10 @@ repo=$1
 file=$2
 output=keybase-secret-${file/\//-}
 
-export KEYBASE_ALLOW_ROOT=1
-
-run_keybase
-sleep 5
-keybase oneshot
+export KEYBASE_SERVICE=1
 
 git clone $repo $HOME/secrets
 
 cp $HOME/secrets/$file $output
 
-echo ::set-output name=file::$output
+echo "file=${output}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Why:
We're using a docker image we don't maintain created by former employee of the company. Since it could be tampered with, we decided to change this action to use the official keybaseio docker image.

### This addresses the issue by:
- Removing naps62 docker image and replace with keybase official

Notes: Based on https://github.com/keybase/client/tree/master/packaging/linux/docker, this is the right "official" image.