### PR TITLE
Upgrade Keybase client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM keybaseio/client:6.1.1-20230104121127-93463966d2-alpine
+FROM keybaseio/client:6.2.4-20240101013525-ae7e4a1c15-alpine
 
 RUN apk add git
 


### PR DESCRIPTION
## What?
Old Keybase clients have an expired certificate so the deployments are failing.
Slack: https://utrust-hq.slack.com/archives/CHY7T0RPW/p1704191705776999