### PR TITLE
Update keybase client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM keybaseio/client:6.2.5-20240101050825+3bdf76f84a-alpine
+FROM keybaseio/client:6.3.0-20240216121342-8bf6d92c02-alpine
 
 RUN apk add git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM keybaseio/client:6.2.4-20240101013525-ae7e4a1c15-alpine
+FROM keybaseio/client:6.2.5-20240101050825+3bdf76f84a-alpine
 
 RUN apk add git
 


### PR DESCRIPTION
We are getting the error below while using the previous version so I updated to the latest version.

`Initializing Keybase... done.
Syncing with Keybase... x509: certificate signed by unknown authority
git-remote-keybase error: (1) x509: certificate signed by unknown authority`

